### PR TITLE
Secure forwarding with DNS over QUIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # secret files such as keys
 /secret
+keylog
 
 # target files
 /target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,9 +869,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.0"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f48b6d60512a392e34dbf7fd456249fd2de3c83669ab642e021903f4015185b"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
  "bytes",
  "libc",
@@ -894,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
  "tokio",
@@ -974,8 +980,9 @@ dependencies = [
 
 [[package]]
 name = "tsein-dns"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes",
  "color-eyre",
@@ -983,6 +990,7 @@ dependencies = [
  "quinn",
  "rand",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.0",
  "stretto",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 authors = ["ClSlaid <cailue@bupt.edu.cn>"]
-description = "A DNS Server."
+description = "[WIP] A DNS server supporting UDP, TCP, TLS and QUIC."
 edition = "2021"
 name = "tsein-dns"
-version = "0.1.2"
+version = "0.1.4"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = "0.1.53"
+anyhow = "1.0.57"
 rand = "0.8.5"
 bytes = "1.1.0"
 color-eyre = "0.6.1"
@@ -18,7 +19,8 @@ thiserror = "1.0.31"
 futures = "0.3.21"
 rustls = "0.20.4"
 rustls-pemfile = "1.0.0"
-tokio = { version = "1.18.0", features = ["full"] }
-tokio-rustls = "0.23.3"
+rustls-native-certs = "0.6.2"
+tokio = { version = "1.18.2", features = ["full"] }
+tokio-rustls = "0.23.4"
 tracing = "0.1.34"
-tracing-subscriber = {version = "0.3.11", features = ["std", "time", "fmt", "local-time"]}
+tracing-subscriber = { version = "0.3.11", features = ["std", "time", "fmt", "local-time"] }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,7 +1,7 @@
 use stretto::AsyncCache;
 use tokio::time;
 
-use crate::protocol::{Question, RRData, RR};
+use crate::protocol::{Question, RR, RRData};
 
 #[derive(Clone)]
 pub struct DnsCache {

--- a/src/comm/client.rs
+++ b/src/comm/client.rs
@@ -1,0 +1,86 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use quinn::NewConnection;
+use rand::random;
+use tokio::sync::mpsc;
+
+use crate::comm::stream::write_packet;
+use crate::comm::{Answer, Task};
+use crate::protocol::{Packet, PacketError, TransactionError};
+
+pub struct QuicForwarder {
+    rec: mpsc::UnboundedReceiver<Task>,
+    connection: quinn::Connection,
+}
+
+impl QuicForwarder {
+    pub async fn try_new(
+        rec: mpsc::UnboundedReceiver<Task>,
+        endpoint: quinn::Endpoint,
+        domain: &'static str,
+        addr: SocketAddr,
+    ) -> Result<Self> {
+        tracing::info!(
+            "establishing quic connection to quic://{}, statically configured as {}",
+            domain,
+            addr
+        );
+        let NewConnection { connection, .. } = endpoint.connect(addr, domain)?.await?;
+
+        Ok(Self { rec, connection })
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        tracing::info!("forward task is running");
+        let checkers = futures::stream::FuturesUnordered::new();
+        let remote = self.connection.remote_address();
+        while let Some(task) = self.rec.recv().await {
+            let Task::Query(q, ans_to) = task;
+            tracing::info!("forwarding new task from transaction layer.");
+            let (mut quic_send, mut quic_recv) = self
+                .connection
+                .open_bi()
+                .await
+                .expect("cannot initiate QUIC stream");
+            let id = random::<u16>();
+            let packet = Packet::new_query(id, q);
+            let checker = tokio::spawn(async move {
+                let r = Packet::parse_stream(&mut quic_recv).await;
+                if let Err(..) = r {
+                    let TransactionError { id, error } = r.unwrap_err();
+                    match error {
+                        PacketError::ServFail => {
+                            tracing::debug!(
+                                "connection closed on stream {} against {}",
+                                quic_recv.id(),
+                                remote
+                            );
+                        }
+                        e => {
+                            let _ = ans_to.send(Answer::Error(e));
+                        }
+                    }
+                    return;
+                }
+                let packet = r.unwrap();
+                tracing::debug!("get answer from upstream: {:?}", packet);
+                for ans in packet.answers {
+                    let _ = ans_to.send(Answer::Answer(ans));
+                }
+                for ns in packet.authorities {
+                    let _ = ans_to.send(Answer::NameServer(ns));
+                }
+                for addi in packet.additions {
+                    let _ = ans_to.send(Answer::Additional(addi));
+                }
+            });
+            checkers.push(checker);
+            let _ = write_packet(&mut quic_send, packet);
+        }
+        for checker in checkers {
+            let _ = tokio::join!(checker);
+        }
+        Ok(())
+    }
+}

--- a/src/comm/forward.rs
+++ b/src/comm/forward.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use tokio::net::UdpSocket;
+use tokio::net::{TcpStream, UdpSocket};
 use tracing;
 
 use crate::comm::{Answer, TaskMap};
@@ -38,9 +38,9 @@ pub async fn listening(forward: Arc<UdpSocket>, map: TaskMap) {
                 }
             }
             Err(TransactionError {
-                    id: Some(id),
-                    error,
-                }) => {
+                id: Some(id),
+                error,
+            }) => {
                 let err = vec![Answer::Error(error)];
                 {
                     let mut guard = map.lock().await;

--- a/src/comm/forward.rs
+++ b/src/comm/forward.rs
@@ -38,9 +38,9 @@ pub async fn listening(forward: Arc<UdpSocket>, map: TaskMap) {
                 }
             }
             Err(TransactionError {
-                id: Some(id),
-                error,
-            }) => {
+                    id: Some(id),
+                    error,
+                }) => {
                 let err = vec![Answer::Error(error)];
                 {
                     let mut guard = map.lock().await;

--- a/src/comm/forward.rs
+++ b/src/comm/forward.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use tokio::net::{TcpStream, UdpSocket};
+use tokio::net::UdpSocket;
 use tracing;
 
 use crate::comm::{Answer, TaskMap};
@@ -38,9 +38,9 @@ pub async fn listening(forward: Arc<UdpSocket>, map: TaskMap) {
                 }
             }
             Err(TransactionError {
-                    id: Some(id),
-                    error,
-                }) => {
+                id: Some(id),
+                error,
+            }) => {
                 let err = vec![Answer::Error(error)];
                 {
                     let mut guard = map.lock().await;

--- a/src/comm/mod.rs
+++ b/src/comm/mod.rs
@@ -14,6 +14,7 @@ pub use stream::{QuicService, TcpService, TlsListener, TlsService};
 
 use crate::protocol::{Packet, PacketError, Question, TransactionError, RR};
 
+pub mod client;
 pub(crate) mod forward;
 pub(crate) mod stream;
 
@@ -56,6 +57,7 @@ impl UdpService {
         }
     }
 
+    #[warn(deprecated_in_future)]
     pub async fn run_forward(
         self: Arc<Self>,
         mut recur_receiver: mpsc::UnboundedReceiver<Task>,
@@ -152,7 +154,7 @@ impl UdpService {
             // validate packet
             if n < 12 {
                 tracing::debug!("received malformed packet from {}", client);
-                tracing::trace!("packet length: {}, data: {:?}", n, packet);
+                tracing::debug!("packet length: {}, data: {:?}", n, packet);
                 // ignore
                 continue;
             }

--- a/src/comm/mod.rs
+++ b/src/comm/mod.rs
@@ -6,13 +6,13 @@ use std::time::Duration;
 use bytes::{Bytes, BytesMut};
 use rand::prelude::random;
 use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, oneshot, Mutex, OnceCell};
+use tokio::sync::{mpsc, Mutex, OnceCell, oneshot};
 use tokio::time::timeout;
 use tracing;
 
 pub use stream::{QuicService, TcpService, TlsListener, TlsService};
 
-use crate::protocol::{Packet, PacketError, Question, TransactionError, RR};
+use crate::protocol::{Packet, PacketError, Question, RR, TransactionError};
 
 pub mod client;
 pub(crate) mod forward;

--- a/src/comm/stream/mod.rs
+++ b/src/comm/stream/mod.rs
@@ -15,8 +15,8 @@ pub(crate) mod worker;
 
 /// use write_packet to write packet into TCP, TLS and IETF-QUIC streams
 pub async fn write_packet<S>(stream: &mut S, packet: Packet) -> Result<(), std::io::Error>
-where
-    S: AsyncWriteExt + Unpin,
+    where
+        S: AsyncWriteExt + Unpin,
 {
     let id = packet.get_id();
     let buf = packet.into_bytes();
@@ -36,8 +36,8 @@ pub(crate) async fn stream_fail<S>(
     stream: &mut S,
     err: TransactionError,
 ) -> Result<(), std::io::Error>
-where
-    S: AsyncWriteExt + Unpin,
+    where
+        S: AsyncWriteExt + Unpin,
 {
     let TransactionError { id, error } = err;
     let id = id.unwrap_or(0);

--- a/src/comm/stream/mod.rs
+++ b/src/comm/stream/mod.rs
@@ -15,8 +15,8 @@ pub(crate) mod worker;
 
 /// use write_packet to write packet into TCP, TLS and IETF-QUIC streams
 pub async fn write_packet<S>(stream: &mut S, packet: Packet) -> Result<(), std::io::Error>
-    where
-        S: AsyncWriteExt + Unpin,
+where
+    S: AsyncWriteExt + Unpin,
 {
     let id = packet.get_id();
     let buf = packet.into_bytes();
@@ -36,8 +36,8 @@ pub(crate) async fn stream_fail<S>(
     stream: &mut S,
     err: TransactionError,
 ) -> Result<(), std::io::Error>
-    where
-        S: AsyncWriteExt + Unpin,
+where
+    S: AsyncWriteExt + Unpin,
 {
     let TransactionError { id, error } = err;
     let id = id.unwrap_or(0);

--- a/src/comm/stream/quic.rs
+++ b/src/comm/stream/quic.rs
@@ -1,12 +1,12 @@
-use bytes::Bytes;
 use std::net::SocketAddr;
 
+use bytes::Bytes;
 use futures::StreamExt;
 use quinn::{Incoming, RecvStream, SendStream};
 use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 
-use crate::comm::stream::{stream_fail, write_packet};
+use crate::comm::stream::stream_fail;
 use crate::comm::{Answer, Task};
 use crate::protocol::{Packet, PacketError, TransactionError};
 
@@ -167,7 +167,7 @@ async fn worker(
             );
             return;
         }
-        send.finish().await;
+        let _ = send.finish().await;
     }
     tracing::debug!("stream {} to quic://{} closed", stream_id, client);
 }

--- a/src/comm/stream/service.rs
+++ b/src/comm/stream/service.rs
@@ -21,8 +21,8 @@ pub trait Listener {
 }
 
 pub struct Service<L>
-where
-    L: Listener + Send + Sync,
+    where
+        L: Listener + Send + Sync,
 {
     listener: L,
     task: mpsc::UnboundedSender<Task>,

--- a/src/comm/stream/tcp.rs
+++ b/src/comm/stream/tcp.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use tokio::io::{ReadHalf, WriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 
-use super::service::Listener;
 use super::Service;
+use super::service::Listener;
 
 pub type TcpService = Service<TcpListener>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 // TODO: refract into a clap application
 use std::fs::File;
 use std::io::BufReader;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use tokio::net::{TcpListener, UdpSocket};
-use tokio::sync::{mpsc, OnceCell};
+use tokio::sync::mpsc;
 use tokio::time;
 use tokio_rustls::rustls::{Certificate, PrivateKey};
 use tracing::instrument;
@@ -247,11 +247,11 @@ async fn run(upstream_domain: &'static str, upstream_addr: SocketAddr) {
 
     tracing::info!("binding port 1954 as quic forwarding port");
     let forward = SocketAddr::new(IpAddr::from(Ipv6Addr::UNSPECIFIED), 1954);
-    let mut quic_config = rustls::ClientConfig::builder()
+    let quic_config = rustls::ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(roots)
         .with_no_client_auth();
-    quic_config.key_log = Arc::new(rustls::KeyLogFile::new());
+
     let mut endpoint = quinn::Endpoint::client(forward).unwrap();
     endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(quic_config)));
     let forwarder = QuicForwarder::try_new(rec_recv, endpoint, upstream_domain, upstream_addr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,17 +156,24 @@ async fn run() {
         }
     };
 
-    let serv_config = match rustls::ServerConfig::builder()
+    let mut serv_config = match rustls::ServerConfig::builder()
         .with_safe_defaults()
         .with_no_client_auth()
         .with_single_cert(certs, keys.remove(0))
     {
-        Ok(cfg) => Arc::new(cfg),
+        Ok(cfg) => cfg,
         Err(e) => {
             tracing::error!("cannot generate server config: {}", e);
             return;
         }
     };
+
+    serv_config.alpn_protocols = vec![
+        Vec::from(&b"dot"[..]),
+        Vec::from(&b"doq"[..]),
+        Vec::from(&b"doq-i11"[..]),
+    ];
+    let serv_config = Arc::new(serv_config);
 
     // init UDP serving ports
     tracing::info!("binding port 1053 as udp serving port");

--- a/src/protocol/header.rs
+++ b/src/protocol/header.rs
@@ -195,8 +195,8 @@ impl Header {
 
 impl Header {
     pub(crate) fn parse(packet: Bytes, pos: usize) -> Result<Self, TransactionError>
-        where
-            Self: Sized,
+    where
+        Self: Sized,
     {
         let mut buf = packet;
         if buf.len() - pos < 12 {
@@ -255,8 +255,8 @@ impl Header {
     }
 
     pub async fn parse_stream<S>(stream: &mut S) -> Result<Self, TransactionError>
-        where
-            S: AsyncReadExt + Unpin,
+    where
+        S: AsyncReadExt + Unpin,
     {
         let error = PacketError::FormatError;
         let id = stream
@@ -353,6 +353,7 @@ impl Header {
         Ok(buf)
     }
 
+    #[warn(dead_code)]
     #[inline]
     fn size(&self) -> usize {
         12
@@ -408,7 +409,7 @@ mod test {
         packet.put_u16(0); // ANCOUNT = 0;
         packet.put_u16(0); // NSCOUNT = 0;
         packet.put_u16(0); // ARCOUNT = 0;
-        // creat question
+                           // creat question
 
         let h_packet = Bytes::from(packet);
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -8,15 +8,15 @@ pub use self::{
     error::{PacketError, TransactionError},
     header::Header,
     question::Question,
-    rr::RR,
     rr::RRData,
+    rr::RR,
 };
 
 trait PacketContent {
     fn size(&self) -> usize;
     fn parse(packet: Bytes, pos: usize) -> Result<Self, PacketError>
-        where
-            Self: Sized;
+    where
+        Self: Sized;
     fn into_bytes(self) -> Result<BytesMut, PacketError>;
 }
 
@@ -117,14 +117,15 @@ impl Packet {
     }
 
     pub async fn parse_stream<S>(stream: &mut S) -> Result<Self, TransactionError>
-        where
-            S: AsyncReadExt + Unpin,
+    where
+        S: AsyncReadExt + Unpin,
     {
         tracing::trace!("parsing packet from stream");
         let len = stream.read_u16().await.map_err(|_| TransactionError {
             id: None,
             error: PacketError::ServFail, // treat as read an EOF, return a ServFail
         })?;
+        tracing::trace!("packet length {}", len);
         let header = Header::parse_stream(stream).await?;
         tracing::trace!("parse header successfully with header: {:?}", header);
         let id = Some(header.get_id());
@@ -408,7 +409,7 @@ mod rr;
 mod integrated_test {
     use bytes::{BufMut, Bytes, BytesMut};
 
-    use crate::protocol::{header::Header, PacketContent, question::Question, RRClass, RRType};
+    use crate::protocol::{header::Header, question::Question, PacketContent, RRClass, RRType};
 
     #[test]
     fn parse_dns_lookup() {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -8,15 +8,15 @@ pub use self::{
     error::{PacketError, TransactionError},
     header::Header,
     question::Question,
-    rr::RRData,
     rr::RR,
+    rr::RRData,
 };
 
 trait PacketContent {
     fn size(&self) -> usize;
     fn parse(packet: Bytes, pos: usize) -> Result<Self, PacketError>
-    where
-        Self: Sized;
+        where
+            Self: Sized;
     fn into_bytes(self) -> Result<BytesMut, PacketError>;
 }
 
@@ -117,8 +117,8 @@ impl Packet {
     }
 
     pub async fn parse_stream<S>(stream: &mut S) -> Result<Self, TransactionError>
-    where
-        S: AsyncReadExt + Unpin,
+        where
+            S: AsyncReadExt + Unpin,
     {
         tracing::debug!("parsing packet from stream");
         let len = stream.read_u16().await.map_err(|_| TransactionError {
@@ -137,9 +137,9 @@ impl Packet {
         }
 
         let to_read = (len - 12) as usize;
-        let mut pkt = BytesMut::from([0_u8; 65535].as_slice());
+        let mut pkt = Vec::from([0; 12]);
         let read = stream
-            .read(&mut pkt[12..])
+            .read_buf(&mut pkt)
             .await
             .map_err(|_| TransactionError {
                 id,
@@ -408,7 +408,7 @@ mod rr;
 mod integrated_test {
     use bytes::{BufMut, Bytes, BytesMut};
 
-    use crate::protocol::{header::Header, question::Question, PacketContent, RRClass, RRType};
+    use crate::protocol::{header::Header, PacketContent, question::Question, RRClass, RRType};
 
     #[test]
     fn parse_dns_lookup() {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -476,7 +476,7 @@ mod integrated_test {
         let outcome = super::Packet::parse_packet(p, 0);
         assert!(outcome.is_ok());
         let pkt = outcome.unwrap();
-        assert_eq!(pkt.question.is_some(), true);
+        assert!(pkt.question.is_some());
         assert_eq!(pkt.answers.len(), 0);
         assert_eq!(pkt.authorities.len(), 0);
         assert_eq!(pkt.additions.len(), 0);

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -8,15 +8,15 @@ pub use self::{
     error::{PacketError, TransactionError},
     header::Header,
     question::Question,
-    rr::RR,
     rr::RRData,
+    rr::RR,
 };
 
 trait PacketContent {
     fn size(&self) -> usize;
     fn parse(packet: Bytes, pos: usize) -> Result<Self, PacketError>
-        where
-            Self: Sized;
+    where
+        Self: Sized;
     fn into_bytes(self) -> Result<BytesMut, PacketError>;
 }
 
@@ -117,16 +117,16 @@ impl Packet {
     }
 
     pub async fn parse_stream<S>(stream: &mut S) -> Result<Self, TransactionError>
-        where
-            S: AsyncReadExt + Unpin,
+    where
+        S: AsyncReadExt + Unpin,
     {
-        tracing::trace!("parsing packet from stream");
+        tracing::debug!("parsing packet from stream");
         let len = stream.read_u16().await.map_err(|_| TransactionError {
             id: None,
             error: PacketError::ServFail, // treat as read an EOF, return a ServFail
         })?;
         let header = Header::parse_stream(stream).await?;
-        tracing::trace!("parse header successfully with header: {:?}", header);
+        tracing::debug!("parse header successfully with header: {:?}", header);
         let id = Some(header.get_id());
         if len < 12 {
             let err = TransactionError {
@@ -408,7 +408,7 @@ mod rr;
 mod integrated_test {
     use bytes::{BufMut, Bytes, BytesMut};
 
-    use crate::protocol::{header::Header, PacketContent, question::Question, RRClass, RRType};
+    use crate::protocol::{header::Header, question::Question, PacketContent, RRClass, RRType};
 
     #[test]
     fn parse_dns_lookup() {

--- a/src/protocol/question.rs
+++ b/src/protocol/question.rs
@@ -46,8 +46,8 @@ impl PacketContent for Question {
     }
 
     fn parse(packet: bytes::Bytes, pos: usize) -> Result<Self, PacketError>
-    where
-        Self: Sized,
+        where
+            Self: Sized,
     {
         let (name, end) = Name::parse(packet.clone(), pos)?;
         let mut p = packet;

--- a/src/protocol/rr/rdata/ns.rs
+++ b/src/protocol/rr/rdata/ns.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BufMut, BytesMut};
 
 use crate::protocol::{domain::Name, error::PacketError};
 
-use super::{try_into_rdata_length, Rdata};
+use super::{Rdata, try_into_rdata_length};
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Ns {
@@ -13,8 +13,8 @@ pub struct Ns {
 
 impl Rdata for Ns {
     fn parse(packet: bytes::Bytes, pos: usize) -> Result<(Self, usize), PacketError>
-    where
-        Self: Sized,
+        where
+            Self: Sized,
     {
         if pos + 4 > packet.len() {
             return Err(PacketError::FormatError);

--- a/src/protocol/rr/rdata/soa.rs
+++ b/src/protocol/rr/rdata/soa.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use crate::protocol::{domain::Name, error::PacketError};
 
-use super::{try_into_rdata_length, Rdata};
+use super::{Rdata, try_into_rdata_length};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Soa {

--- a/src/protocol/rr/rdata/unknown.rs
+++ b/src/protocol/rr/rdata/unknown.rs
@@ -20,9 +20,9 @@ impl Unknown {
         self.rtype = RRType::UNKNOWN(rtype);
     }
 
-    pub fn parse_typeless(packet: bytes::Bytes, pos: usize) -> Result<(Self, usize), PacketError>
-        where
-            Self: Sized,
+    pub fn parse_typeless(packet: Bytes, pos: usize) -> Result<(Self, usize), PacketError>
+    where
+        Self: Sized,
     {
         let mut p = packet;
         let length = p.get_u16() as usize;
@@ -40,9 +40,9 @@ impl Unknown {
 impl Rdata for Unknown {
     /// Warning: will look backward to other fields in RR.
     /// use only when parsing at least a whole RR.
-    fn parse(packet: bytes::Bytes, pos: usize) -> Result<(Self, usize), PacketError>
-        where
-            Self: Sized,
+    fn parse(packet: Bytes, pos: usize) -> Result<(Self, usize), PacketError>
+    where
+        Self: Sized,
     {
         let packet_len = packet.len();
         if pos < 8 || pos > packet_len {
@@ -120,7 +120,7 @@ fn test_parse_and_to_bytes() {
             0, 233_u8, 0, 0, 0, 0, 0, 0, // 233 is the unknown type
             0_u8, 4, 0, 0, 2, 0, // this line is rdlength and rdata section
         ]
-            .to_vec(),
+        .to_vec(),
     );
     let parsed = Unknown::parse(full_data.clone(), 8);
     assert!(parsed.is_ok());


### PR DESCRIPTION
replace default forwarding channel with DNS over QUIC.
Using AdGuard as upstream. (quic://dns-unfiltered.adguard.com)